### PR TITLE
Use ITransmutationProxy API method to retrieve offline knowledge providers

### DIFF
--- a/src/main/java/cool/furry/mc/forge/projectexpansion/block/entity/BlockEntityEMCLink.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/block/entity/BlockEntityEMCLink.java
@@ -9,6 +9,7 @@ import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.capabilities.PECapabilities;
 import moze_intel.projecte.api.capabilities.block_entity.IEmcStorage;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import moze_intel.projecte.emc.nbt.NBTManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -44,7 +45,6 @@ import javax.annotation.Nullable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.Objects;
 
 @SuppressWarnings("unused")
 public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHasMatter {
@@ -104,9 +104,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
         resetLimits();
         if (emc.equals(BigInteger.ZERO)) return;
         ServerPlayer player = Util.getPlayer(level, owner);
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-        if (provider == null) return;
-
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
         BigInteger toAdd = getMatter() == Matter.FINAL ? emc : remainingEMC.min(emc);
         provider.setEmc(provider.getEmc().add(toAdd));
         emc = emc.subtract(toAdd).max(BigInteger.ZERO);
@@ -187,11 +185,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
                 return InteractionResult.CONSUME;
             }
             long cost = fluidHandler.getFluidCost(1000);
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if(provider == null) {
-                player.displayClientMessage(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, Util.getPlayer(owner) == null ? owner : Objects.requireNonNull(Util.getPlayer(owner)).getDisplayName()), true);
-                return InteractionResult.FAIL;
-            }
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             BigInteger emc = provider.getEmc();
             if(emc.compareTo(BigInteger.valueOf(cost)) < 0) {
                 player.displayClientMessage(Lang.Blocks.EMC_LINK_NOT_ENOUGH_EMC.translateColored(ChatFormatting.RED, Component.literal(EMCFormat.format(BigInteger.valueOf(IEMCProxy.INSTANCE.getValue(itemStack)))).setStyle(ColorStyle.GREEN)), true);
@@ -276,8 +270,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
         @Override
         public ItemStack getStackInSlot(int slot) {
             if (slot != 0 || itemStack.isEmpty()) return ItemStack.EMPTY;
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if (provider == null) return ItemStack.EMPTY;
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             BigInteger val = BigInteger.valueOf(IEMCProxy.INSTANCE.getValue(itemStack));
             if(val.equals(BigInteger.ZERO)) return ItemStack.EMPTY;
             BigInteger maxCount = provider.getEmc().divide(val).min(BigInteger.valueOf(Integer.MAX_VALUE));
@@ -304,8 +297,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
             int insertCount = isFinal ? count : Math.min(count, remainingImport);
             if (!simulate) {
                 long itemValue = IEMCProxy.INSTANCE.getSellValue(stack);
-                @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-                if (provider == null) return stack;
+                IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
                 BigInteger totalValue = BigInteger.valueOf(itemValue).multiply(BigInteger.valueOf(insertCount));
                 provider.setEmc(provider.getEmc().add(totalValue));
                 ServerPlayer player = Util.getPlayer(owner);
@@ -336,8 +328,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
 
             BigInteger itemValue = BigInteger.valueOf(IEMCProxy.INSTANCE.getValue(itemStack));
             if(itemValue.equals(BigInteger.ZERO)) return ItemStack.EMPTY;
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if (provider == null) return ItemStack.EMPTY;
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             BigInteger maxCount = provider.getEmc().divide(itemValue).min(BigInteger.valueOf(Integer.MAX_VALUE));
             int extractCount = Math.min(amount, limit && !isFinal ? Math.min(maxCount.intValueExact(), remainingExport) : maxCount.intValueExact());
             if (extractCount <= 0) return ItemStack.EMPTY;
@@ -458,8 +449,7 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
             if(!isFinal && maxDrain > remainingFluid) maxDrain = remainingFluid;
             if(maxDrain > remainingFluid) maxDrain = remainingFluid;
             long cost = getFluidCost(maxDrain);
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if(provider == null) return FluidStack.EMPTY;
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             BigInteger emc = provider.getEmc();
             BigDecimal dEMC = new BigDecimal(emc);
             if(dEMC.compareTo(BigDecimal.valueOf(getFluidCostPer())) < 0) return FluidStack.EMPTY;
@@ -476,7 +466,8 @@ public class BlockEntityEMCLink extends BlockEntityNBTFilterable implements IHas
                 markDirty();
                 if(!isFreeFluid()) {
                     provider.setEmc(emc.subtract(BigInteger.valueOf(cost)));
-                    provider.syncEmc(Objects.requireNonNull(Util.getPlayer(owner)));
+                    ServerPlayer player = Util.getPlayer(owner);
+                    if (player != null) provider.syncEmc(player);
                 }
             }
             return new FluidStack(fluid, maxDrain);

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/block/entity/BlockEntityTransmutationInterface.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/block/entity/BlockEntityTransmutationInterface.java
@@ -6,6 +6,7 @@ import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.ItemInfo;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import moze_intel.projecte.emc.nbt.NBTManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -36,18 +37,12 @@ public class BlockEntityTransmutationInterface extends BlockEntityNBTFilterable 
 
     private ItemInfo[] fetchKnowledge() {
         if (info != null) return info;
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-        if(provider == null) {
-            return new ItemInfo[]{};
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
         return info = provider.getKnowledge().toArray(new ItemInfo[0]);
     }
 
     private int getMaxCount(int slot) {
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-        if(provider == null) {
-            return 0;
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
         BigInteger playerEmc = provider.getEmc();
         if (playerEmc.compareTo(BigInteger.ZERO) < 1) return 0;
         BigInteger targetItemEmc = BigInteger.valueOf(IEMCProxy.INSTANCE.getValue(fetchKnowledge()[slot]));
@@ -104,8 +99,7 @@ public class BlockEntityTransmutationInterface extends BlockEntityNBTFilterable 
             if (simulate) return ItemStack.EMPTY;
 
             long emcValue = IEMCProxy.INSTANCE.getSellValue(stack);
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if(provider == null) return stack;
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             BigInteger totalEmcValue = BigInteger.valueOf(emcValue).multiply(BigInteger.valueOf(count));
             provider.setEmc(provider.getEmc().add(totalEmcValue));
 
@@ -133,8 +127,7 @@ public class BlockEntityTransmutationInterface extends BlockEntityNBTFilterable 
             if (simulate) return item;
             long emcValue = IEMCProxy.INSTANCE.getValue(fetchKnowledge()[slot - 1]);
             BigInteger totalEmcCost = BigInteger.valueOf(emcValue).multiply(BigInteger.valueOf(amount));
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-            if(provider == null) return ItemStack.EMPTY;
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
             provider.setEmc(provider.getEmc().subtract(totalEmcCost));
             ServerPlayer player = Util.getPlayer(level, owner);
             if (player != null) provider.syncEmc(player);

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/commands/CommandEMC.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/commands/CommandEMC.java
@@ -8,8 +8,8 @@ import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.util.ColorStyle;
 import cool.furry.mc.forge.projectexpansion.util.EMCFormat;
 import cool.furry.mc.forge.projectexpansion.util.Lang;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
@@ -101,11 +101,7 @@ public class CommandEMC {
     private static int handle(CommandContext<CommandSourceStack> ctx, ActionType action) throws CommandSyntaxException {
         ServerPlayer player = EntityArgument.getPlayer(ctx, "player");
         if(action == ActionType.GET) {
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-            if(provider == null) {
-                ctx.getSource().sendFailure(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()));
-                return 0;
-            }
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
             if (compareUUID(ctx.getSource(), player)) {
                 sendSuccess(ctx.getSource(), Lang.Commands.EMC_GET_SUCCESS_SELF.translate(formatEMC(provider.getEmc())), false);
             } else {
@@ -144,11 +140,7 @@ public class CommandEMC {
         }
 
         int response = 1;
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if(provider == null) {
-            ctx.getSource().sendFailure(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()));
-            return 0;
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
         BigInteger newEMC = provider.getEmc();
         switch (action) {
             case ADD -> {

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/commands/CommandKnowledge.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/commands/CommandKnowledge.java
@@ -5,10 +5,10 @@ import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.util.Lang;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.ItemInfo;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import moze_intel.projecte.emc.nbt.NBTManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.CommandBuildContext;
@@ -20,8 +20,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
-
-import javax.annotation.Nullable;
 
 public class CommandKnowledge {
     private enum ActionType {
@@ -89,11 +87,7 @@ public class CommandKnowledge {
         ServerPlayer player = EntityArgument.getPlayer(ctx, "player");
         boolean isSelf = compareUUID(ctx.getSource(), player);
         if(action == ActionType.CLEAR) {
-            @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-            if(provider == null) {
-                ctx.getSource().sendFailure(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()));
-                return 0;
-            }
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
             if(provider.getKnowledge().isEmpty()) {
                 if(isSelf) {
                     ctx.getSource().sendFailure(Lang.Commands.KNOWLEDGE_CLEAR_FAIL_SELF.translateColored(ChatFormatting.RED));
@@ -116,11 +110,7 @@ public class CommandKnowledge {
         }
         Item item = ItemArgument.getItem(ctx, "item").getItem();
 
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if(provider == null) {
-            ctx.getSource().sendFailure(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()));
-            return 0;
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
         IEMCProxy proxy = IEMCProxy.INSTANCE;
         if (!proxy.hasValue(item)) {
             ctx.getSource().sendFailure(Lang.Commands.KNOWLEDGE_INVALID.translate());

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/events/ItemTooltipEvent.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/events/ItemTooltipEvent.java
@@ -6,11 +6,10 @@ import cool.furry.mc.forge.projectexpansion.registries.Enchantments;
 import cool.furry.mc.forge.projectexpansion.util.ColorStyle;
 import cool.furry.mc.forge.projectexpansion.util.Lang;
 import cool.furry.mc.forge.projectexpansion.util.TagNames;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.ItemInfo;
-import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import moze_intel.projecte.config.ProjectEConfig;
 import moze_intel.projecte.utils.EMCHelper;
 import moze_intel.projecte.utils.text.PELang;
@@ -43,10 +42,7 @@ public class ItemTooltipEvent {
                 break learnedTooltip;
             }
 
-            IKnowledgeProvider provider = Util.getKnowledgeProvider(event.getEntity());
-            if (provider == null) {
-                break learnedTooltip;
-            }
+            IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(event.getEntity().getUUID());
 
             boolean hasKnowledge = provider.hasKnowledge(ItemInfo.fromStack(stack));
             long value = IEMCProxy.INSTANCE.getValue(stack);

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemInfiniteFuel.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemInfiniteFuel.java
@@ -1,9 +1,9 @@
 package cool.furry.mc.forge.projectexpansion.item;
 
-import cool.furry.mc.forge.projectexpansion.Main;
 import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.util.*;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -38,8 +38,8 @@ public class ItemInfiniteFuel extends Item {
     @Override
     public int getBurnTime(ItemStack stack, @Nullable RecipeType<?> recipeType) {
         @Nullable UUID owner = stack.getTag() == null ? null : stack.getTag().getUUID(TagNames.OWNER);
-        @Nullable IKnowledgeProvider provider = owner == null ? null : Util.getKnowledgeProvider(owner);
-        if (owner == null || provider == null) return 0;
+        if (owner == null) return 0;
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
         return (Config.infiniteFuelCost.get() == 0 || Config.infiniteFuelBurnTime.get() == 0) ? 0 : provider.getEmc().compareTo(BigInteger.valueOf(Config.infiniteFuelCost.get())) < 0 ? 0 : Config.infiniteFuelBurnTime.get();
     }
 
@@ -54,8 +54,7 @@ public class ItemInfiniteFuel extends Item {
         if (owner == null)
             return stack;
         ServerPlayer player = Util.getPlayer(owner);
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(owner);
-        if (provider == null) return stack;
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
         provider.setEmc(provider.getEmc().subtract(BigInteger.valueOf(Config.infiniteFuelCost.get())));
         if (player != null) provider.syncEmc(player);
         return stack;

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemInfiniteSteak.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemInfiniteSteak.java
@@ -1,12 +1,11 @@
 package cool.furry.mc.forge.projectexpansion.item;
 
-import cool.furry.mc.forge.projectexpansion.Main;
 import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.util.ColorStyle;
 import cool.furry.mc.forge.projectexpansion.util.EMCFormat;
 import cool.furry.mc.forge.projectexpansion.util.Lang;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
@@ -57,8 +56,8 @@ public class ItemInfiniteSteak extends Item {
     @Override
     public InteractionResultHolder<ItemStack> use(Level level, Player player, InteractionHand hand) {
         ItemStack stack = player.getItemInHand(hand);
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if (!player.canEat(false) || Config.infiniteSteakCost.get() == 0 || provider == null || provider.getEmc().compareTo(BigInteger.valueOf(Config.infiniteSteakCost.get())) < 0) return InteractionResultHolder.fail(stack);
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
+        if (!player.canEat(false) || Config.infiniteSteakCost.get() == 0 || provider.getEmc().compareTo(BigInteger.valueOf(Config.infiniteSteakCost.get())) < 0) return InteractionResultHolder.fail(stack);
         player.startUsingItem(hand);
         return InteractionResultHolder.sidedSuccess(stack, level.isClientSide);
     }
@@ -66,11 +65,7 @@ public class ItemInfiniteSteak extends Item {
     @Override
     public ItemStack finishUsingItem(ItemStack stack, Level level, LivingEntity entity) {
         if (!(entity instanceof ServerPlayer player) || level.isClientSide) return stack;
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if (provider == null) {
-            player.displayClientMessage(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()), true);
-            return stack;
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
         BigInteger emc = provider.getEmc().subtract(BigInteger.valueOf(Config.infiniteSteakCost.get()));
         if (emc.compareTo(BigInteger.ZERO) < 0) {
             player.displayClientMessage(Lang.Items.INFINITE_STEAK_NOT_ENOUGH_EMC.translateColored(ChatFormatting.RED, Component.literal(Config.infiniteSteakCost.get().toString())), true);

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemKnowledgeSharingBook.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemKnowledgeSharingBook.java
@@ -1,14 +1,13 @@
 package cool.furry.mc.forge.projectexpansion.item;
 
-import cool.furry.mc.forge.projectexpansion.Main;
 import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.registries.SoundEvents;
 import cool.furry.mc.forge.projectexpansion.util.ColorStyle;
 import cool.furry.mc.forge.projectexpansion.util.Lang;
 import cool.furry.mc.forge.projectexpansion.util.TagNames;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.ItemInfo;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.particles.ItemParticleOption;
 import net.minecraft.core.particles.ParticleTypes;
@@ -28,7 +27,6 @@ import net.minecraft.world.phys.Vec3;
 
 import javax.annotation.Nullable;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 
 public class ItemKnowledgeSharingBook extends Item {
@@ -58,16 +56,8 @@ public class ItemKnowledgeSharingBook extends Item {
                     return InteractionResultHolder.fail(stack);
                 }
                 if(!level.isClientSide) {
-                    @Nullable IKnowledgeProvider ownerProvider = Util.getKnowledgeProvider(owner);
-                    @Nullable IKnowledgeProvider learnerProvider = Util.getKnowledgeProvider(player);
-                    if(ownerProvider == null) {
-                        player.displayClientMessage(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, Util.getPlayer(owner) == null ? owner : Objects.requireNonNull(Util.getPlayer(owner)).getDisplayName()), true);
-                        return InteractionResultHolder.fail(stack);
-                    }
-                    if(learnerProvider == null) {
-                        player.displayClientMessage(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()), true);
-                        return InteractionResultHolder.fail(stack);
-                    }
+                    IKnowledgeProvider ownerProvider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(owner);
+                    IKnowledgeProvider learnerProvider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
                     long learned = 0;
                     for(ItemInfo info : ownerProvider.getKnowledge()) {
                         if(!learnerProvider.hasKnowledge(info)) {

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemMatterUpgrader.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/item/ItemMatterUpgrader.java
@@ -1,11 +1,10 @@
 package cool.furry.mc.forge.projectexpansion.item;
 
-import cool.furry.mc.forge.projectexpansion.Main;
 import cool.furry.mc.forge.projectexpansion.block.entity.*;
 import cool.furry.mc.forge.projectexpansion.util.*;
-import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -67,11 +66,7 @@ public class ItemMatterUpgrader extends Item {
         }
 
 
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if(provider == null) {
-            player.displayClientMessage(Lang.FAILED_TO_GET_KNOWLEDGE_PROVIDER.translateColored(ChatFormatting.RED, player.getDisplayName()), true);
-            return InteractionResult.FAIL;
-        }
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
         IEMCProxy proxy = IEMCProxy.INSTANCE;
 
         @Nullable BlockItem upgrade = null;

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/mixin/AlchemicalCollectionMixin.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/mixin/AlchemicalCollectionMixin.java
@@ -4,11 +4,10 @@ import cool.furry.mc.forge.projectexpansion.config.Config;
 import cool.furry.mc.forge.projectexpansion.registries.Enchantments;
 import cool.furry.mc.forge.projectexpansion.registries.SoundEvents;
 import cool.furry.mc.forge.projectexpansion.util.TagNames;
-import cool.furry.mc.forge.projectexpansion.util.Util;
 import moze_intel.projecte.api.ItemInfo;
-import moze_intel.projecte.api.ProjectEAPI;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
 import moze_intel.projecte.api.proxy.IEMCProxy;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import moze_intel.projecte.emc.nbt.NBTManager;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
@@ -25,7 +24,6 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +37,7 @@ public abstract class AlchemicalCollectionMixin {
     @Inject(at = @At("RETURN"), method = "getDrops(Lnet/minecraft/world/level/block/state/BlockState;Lnet/minecraft/server/level/ServerLevel;Lnet/minecraft/core/BlockPos;Lnet/minecraft/world/level/block/entity/BlockEntity;Lnet/minecraft/world/entity/Entity;Lnet/minecraft/world/item/ItemStack;)Ljava/util/List;", cancellable = true)
     private static void getDrops(BlockState state, ServerLevel level, BlockPos pos, BlockEntity blockEntity, Entity entity, ItemStack stack, CallbackInfoReturnable<List<ItemStack>> cir) {
         if(!(entity instanceof ServerPlayer player)) return;
-        @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(player);
-        if(provider == null) return;
+        IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(player.getUUID());
         IEMCProxy proxy = IEMCProxy.INSTANCE;
         boolean hasEnch = EnchantmentHelper.getTagEnchantmentLevel(Enchantments.ALCHEMICAL_COLLECTION.get(), stack) > 0;
         if(!state.canHarvestBlock(level, pos, player) || !hasEnch) return;

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/util/PowerFlowerCollector.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/util/PowerFlowerCollector.java
@@ -2,12 +2,12 @@ package cool.furry.mc.forge.projectexpansion.util;
 
 import cool.furry.mc.forge.projectexpansion.Main;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
+import moze_intel.projecte.api.proxy.ITransmutationProxy;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 
-import javax.annotation.Nullable;
 import java.math.BigInteger;
 import java.util.*;
 
@@ -28,12 +28,10 @@ public class PowerFlowerCollector {
             Set<UUID> toRemove = new HashSet<>();
             for(UUID uuid : stored.keySet()) {
                 BigInteger amount = stored.get(uuid);
-                ServerPlayer player = Util.getPlayer(uuid);
-                if (player == null) continue;
-                @Nullable IKnowledgeProvider provider = Util.getKnowledgeProvider(uuid);
-                if(provider == null) continue;
+                IKnowledgeProvider provider = ITransmutationProxy.INSTANCE.getKnowledgeProviderFor(uuid);
                 provider.setEmc(provider.getEmc().add(amount));
-                provider.syncEmc(player);
+                ServerPlayer player = Util.getPlayer(uuid);
+                if (player != null) provider.syncEmc(player);
                 toRemove.add(uuid);
             }
             toRemove.forEach(stored::remove);

--- a/src/main/java/cool/furry/mc/forge/projectexpansion/util/Util.java
+++ b/src/main/java/cool/furry/mc/forge/projectexpansion/util/Util.java
@@ -2,7 +2,6 @@ package cool.furry.mc.forge.projectexpansion.util;
 
 import moze_intel.projecte.api.ItemInfo;
 import moze_intel.projecte.api.capabilities.IKnowledgeProvider;
-import moze_intel.projecte.api.capabilities.PECapabilities;
 import moze_intel.projecte.api.capabilities.block_entity.IEmcStorage;
 import moze_intel.projecte.api.event.PlayerAttemptLearnEvent;
 import moze_intel.projecte.emc.nbt.NBTManager;
@@ -126,22 +125,6 @@ public class Util {
     public static void markDirty(Level level, BlockPos pos) {
         level.getChunkAt(pos).setUnsaved(true);
         level.sendBlockUpdated(pos, level.getBlockState(pos), level.getBlockState(pos), Block.UPDATE_CLIENTS);
-    }
-
-    public static @Nullable IKnowledgeProvider getKnowledgeProvider(UUID uuid) {
-        @Nullable ServerPlayer player = getPlayer(uuid);
-        if(player == null) {
-            return null;
-        }
-        return getKnowledgeProvider(player);
-    }
-
-    public static @Nullable IKnowledgeProvider getKnowledgeProvider(Player player) {
-        try {
-            return player.getCapability(PECapabilities.KNOWLEDGE_CAPABILITY).orElseThrow(NullPointerException::new);
-        } catch(NullPointerException ignore) {
-            return null;
-        }
     }
 
     public static long spreadEMC(long emc, List<IEmcStorage> storageList) {


### PR DESCRIPTION
Currently, the way that Project Expansion works is that blocks such as the EMC Link are completely unusable when the owning player is not connected to a multiplayer server. However, ProjectE provides support just fine for offline EMC and knowledge manipulation via the `ITransmutationProxy` API class, which will retrieve either an online player's knowledge capability or an offline instance of that player's knowledge provider, the latter working as a queue for EMC/knowledge actions for when the player rejoins the server.

This PR removes the `Util::getKnowledgeProvider` methods in favour of this API proxy method, allowing blocks such as the EMC Link to be operational even while their owner is offline. Do note that contrary to what has been said in #105, it is perfectly safe to do this as the `IKnowledgeProvider` this method returns is *never* `null`: it will either query an online player's capability, or return a new `TransmutationOffline` instance as an implementation.